### PR TITLE
Fix deprecated require warnings in Rails 4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Fix deprecated attribute_accessors require.
+
 # 1.0.2
 
 * Fix load order problem with other gems.

--- a/actionpack-page_caching.gemspec
+++ b/actionpack-page_caching.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'actionpack-page_caching'
-  gem.version       = '1.0.2'
+  gem.version       = '1.0.3'
   gem.author        = 'David Heinemeier Hansson'
   gem.email         = 'david@loudthinking.com'
   gem.description   = 'Static page caching for Action Pack (removed from core in Rails 4.0)'

--- a/lib/action_controller/caching/pages.rb
+++ b/lib/action_controller/caching/pages.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'active_support/core_ext/class/attribute_accessors'
+require 'active_support/core_ext/module/attribute_accessors'
 
 module ActionController
   module Caching


### PR DESCRIPTION
Require module/attribute_accessors instead of class/attribute_accessors. Nothing big here—I just don't like seeing warnings. Tested in Rails 4.1.0.rc1 and 4.0.4.
