### PR TITLE
Update README: still maintained after Rails 4.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ actionpack-page_caching
 
 Static page caching for Action Pack (removed from core in Rails 4.0).
 
-**NOTE:** It will continue to be officially maintained until Rails 4.1.
-
 Installation
 ------------
 


### PR DESCRIPTION
According to @rafaelfranca, this repo almost doesn't have issues and
it's hard to break, so we can keep on maintaining it even now that
Rails 4.2 is out.

Once we want to remove support, we will probably announce it with an
official statement in a blog post.

[ci skip]