### PR TITLE
Fix tests

### DIFF
--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -1,4 +1,5 @@
 require 'abstract_unit'
+require 'mocha/setup'
 
 CACHE_DIR = 'test_cache'
 # Don't change '/../temp/' cavalierly or you might hose something you don't want hosed


### PR DESCRIPTION
Now that the rails gem points to 4.2, we need to:

* require mocha in order to use the `expects` syntax, otherwise tests will fail. 
* ~~specify the test order of ActiveSupport::TestCase, otherwise a deprecation warning will show up.~~

See https://travis-ci.org/rails/actionpack-page_caching/builds/46021659