### PR TITLE
middleware checking for cached files before calling Rails app

### DIFF
--- a/actionpack-page_caching.gemspec
+++ b/actionpack-page_caching.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'actionpack-page_caching'
-  gem.version       = '1.0.2'
+  gem.version       = '1.0.3'
   gem.author        = 'David Heinemeier Hansson'
   gem.email         = 'david@loudthinking.com'
   gem.description   = 'Static page caching for Action Pack (removed from core in Rails 4.0)'

--- a/lib/actionpack/page_caching/serve_static.rb
+++ b/lib/actionpack/page_caching/serve_static.rb
@@ -1,0 +1,21 @@
+module ActionPack
+  module PageCaching
+    class ServeStatic
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          if @app.config.action_controller.perform_caching
+            cache_file =
+                "#{@app.config.action_controller.page_cache_directory.to_s.gsub(/\/$/,'')}#{env['PATH_INFO']}.html"
+            if File.exist?(cache_file) && File.readable?(cache_file)
+              response = Rack::Response.new [File.read(cache_file)]
+              return [200, response.headers, response.body]
+            end
+          end
+          @app.call(env)
+        end
+    end
+  end
+end


### PR DESCRIPTION
For those on shared hostings without access to Apache/Nginx config. 
The usage would be to put 

``` ruby
require 'actionpack/page_caching/serve_static'
use ::ActionPack::PageCaching::ServeStatic
```

in config.ru before `run Rails.application`

Ofc, it's slower that configuring the server to serve those files directly. But still worth having. 

It's my first contribution, so please let me know of any junk I made. And suggestion how to make automatic tests for middleware are very welcome (If it doesn't fit here, maybe it should be separate gem?)
