### PR TITLE
Update dependencies to work with Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,25 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
+  - 2.2.4
+  - 2.3.0
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4-0-stable
   - gemfiles/Gemfile-4-1-stable
+  - gemfiles/Gemfile-4-2-stable
   - gemfiles/Gemfile-edge
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile-edge
+      rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile-edge
+      rvm: 2.0.0
+    - gemfile: gemfiles/Gemfile-edge
+      rvm: 2.1
+    - gemfile: gemfiles/Gemfile-edge
+      rvm: 2.2
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,13 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.2.4
   - 2.3.0
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile-4-0-stable
-  - gemfiles/Gemfile-4-1-stable
-  - gemfiles/Gemfile-4-2-stable
   - gemfiles/Gemfile-edge
 matrix:
   allow_failures:
-    - gemfile: gemfiles/Gemfile-edge
-      rvm: 1.9.3
-    - gemfile: gemfiles/Gemfile-edge
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile-edge
-      rvm: 2.1
-    - gemfile: gemfiles/Gemfile-edge
-      rvm: 2.2
 notifications:
   email: false
   irc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+* Add support for Rails 5.0.x
+
 # 1.0.2
 
 * Fix load order problem with other gems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.0.3
+# 2.0.0
 
-* Add support for Rails 5.0.x
+* Add support for Rails 5.0.x, remove support for Rails 4
 
 # 1.0.2
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rails'
+gem 'rails', '>= 5.0.0beta1.0'

--- a/actionpack-page_caching.gemspec
+++ b/actionpack-page_caching.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'actionpack-page_caching'
-  gem.version       = '1.0.2'
+  gem.version       = '1.0.3'
   gem.author        = 'David Heinemeier Hansson'
   gem.email         = 'david@loudthinking.com'
   gem.description   = 'Static page caching for Action Pack (removed from core in Rails 4.0)'
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'actionpack', '>= 4.0.0', '< 5'
+  gem.add_dependency 'actionpack', '>= 4.0.0', '< 5.1'
 
   gem.add_development_dependency 'mocha'
 end

--- a/actionpack-page_caching.gemspec
+++ b/actionpack-page_caching.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'actionpack-page_caching'
-  gem.version       = '1.0.3'
+  gem.version       = '2.0.0'
   gem.author        = 'David Heinemeier Hansson'
   gem.email         = 'david@loudthinking.com'
   gem.description   = 'Static page caching for Action Pack (removed from core in Rails 4.0)'
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'actionpack', '>= 4.0.0', '< 5.1'
+  gem.add_dependency 'actionpack', '>= 4.1.0', '< 5.1'
 
   gem.add_development_dependency 'mocha'
 end

--- a/gemfiles/Gemfile-4-0-stable
+++ b/gemfiles/Gemfile-4-0-stable
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'rails', github: 'rails/rails', branch: '4-0-stable'

--- a/gemfiles/Gemfile-4-1-stable
+++ b/gemfiles/Gemfile-4-1-stable
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'rails', github: 'rails/rails', branch: '4-1-stable'

--- a/gemfiles/Gemfile-4-2-stable
+++ b/gemfiles/Gemfile-4-2-stable
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'rails', github: 'rails/rails', branch: '4-2-stable'

--- a/gemfiles/Gemfile-4-2-stable
+++ b/gemfiles/Gemfile-4-2-stable
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', github: 'rails/rails', branch: '4-2-stable'

--- a/lib/action_controller/caching/pages.rb
+++ b/lib/action_controller/caching/pages.rb
@@ -120,7 +120,7 @@ module ActionController
             Zlib::BEST_COMPRESSION
           end
 
-          after_filter({only: actions}.merge(options)) do |c|
+          after_action({only: actions}.merge(options)) do |c|
             c.cache_page(nil, nil, gzip_level)
           end
         end

--- a/test/caching_test.rb
+++ b/test/caching_test.rb
@@ -78,20 +78,20 @@ class PageCachingTestController < CachingController
   end
 
   def custom_path
-    render text: 'Super soaker'
+    render html: 'Super soaker'
     cache_page('Super soaker', '/index.html')
   end
 
   def default_gzip
-    render text: 'Text'
+    render html: 'Text'
   end
 
   def no_gzip
-    render text: 'PNG'
+    render html: 'PNG'
   end
 
   def gzip_level
-    render text: 'Big text'
+    render html: 'Big text'
   end
 
   def expire_custom_path
@@ -100,13 +100,13 @@ class PageCachingTestController < CachingController
   end
 
   def trailing_slash
-    render text: 'Sneak attack'
+    render html: 'Sneak attack'
   end
 
   def about_me
     respond_to do |format|
-      format.html { render text: 'I am html' }
-      format.xml  { render text: 'I am xml'  }
+      format.html { render html: 'I am html' }
+      format.xml  { render xml: 'I am xml'  }
     end
   end
 end
@@ -115,7 +115,11 @@ class PageCachingTest < ActionController::TestCase
   def setup
     super
 
-    @request = ActionController::TestRequest.new
+    @request = if ActionController::TestRequest.respond_to?(:create)
+      ActionController::TestRequest.create
+    else
+      ActionController::TestRequest.new
+    end
     @request.host = 'hostname.com'
     @request.env.delete('PATH_INFO')
 
@@ -123,7 +127,11 @@ class PageCachingTest < ActionController::TestCase
     @controller.perform_caching = true
     @controller.cache_store = :file_store, FILE_STORE_PATH
 
-    @response   = ActionController::TestResponse.new
+    @response = if ActionController.const_defined?('TestResponse')
+      ActionController::TestResponse.new
+    else
+      ActionDispatch::TestResponse.new
+    end
 
     @params = { controller: 'posts', action: 'index', only_path: true }
 

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -10,7 +10,7 @@ module Another
 
     def with_page_cache
       cache_page('Super soaker', '/index.html')
-      render nothing: true
+      render body: nil
     end
   end
 end

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -10,7 +10,7 @@ module Another
 
     def with_page_cache
       cache_page('Super soaker', '/index.html')
-      render body: nil
+      head :ok
     end
   end
 end


### PR DESCRIPTION
Addresses #31 - seems like it works as desired right out of the box. Here's how I tested compatibility with Rails 5.0.0.beta1.1:

```
gem install rails --pre
rails new rails5
cd rails5
bin/rails g controller Main
```

Add `get '/', :to => 'main#show'` to `routes.rb`

MainController.rb:

```
class MainController < ApplicationController
  caches_page :show

  def show
  end
end
```

app/views/main/show.html.erb:

```
Hello, world.
```

Then `RAILS_ENV=production bin/rails s`, go to `localhost:3000`. Then I found this in `public/index.html`:

```
<!DOCTYPE html>
<html>
  <head>
    <title>Rails5</title>
    <meta name="csrf-param" content="authenticity_token" />
<meta name="csrf-token" content="..." />
    <meta name="action-cable-url" content="/cable" />

    <link rel="stylesheet" media="all" href="/stylesheets/application.css" data-turbolinks-track="true" />
    <script src="/javascripts/application.js" data-turbolinks-track="true"></script>
  </head>

  <body>
    Hello, world.

  </body>
</html>
```

and on `production.log`:

```
I, [2016-01-25T16:35:45.127717 #33086]  INFO -- : Started GET "/" for 127.0.0.1 at 2016-01-25 16:35:45 -0500
I, [2016-01-25T16:35:45.131745 #33086]  INFO -- : Processing by MainController#show as HTML
I, [2016-01-25T16:35:45.142266 #33086]  INFO -- :   Rendered main/show.html.erb within layouts/application (0.3ms)
I, [2016-01-25T16:35:45.147295 #33086]  INFO -- : Write page /Users/sjagr/GitRepos/rails5/public/index.html (0.3ms)
I, [2016-01-25T16:35:45.147512 #33086]  INFO -- : Completed 200 OK in 16ms (Views: 6.9ms | ActiveRecord: 0.0ms)
```

I took the liberty of bumping the version to 1.0.3 and adding a note to the CHANGELOG as well. I'm wondering if any new tests would be necessary with newer Ruby and Rails versions.