### PR TITLE
Fix build on Ruby 1.9.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.3.1
 gemfile:
   - Gemfile
   - gemfiles/Gemfile-4-0-stable
   - gemfiles/Gemfile-4-1-stable
+  - gemfiles/Gemfile-4-2-stable
   - gemfiles/Gemfile-edge
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails'
+gem "mime-types", "< 3"

--- a/gemfiles/Gemfile-4-0-stable
+++ b/gemfiles/Gemfile-4-0-stable
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', github: 'rails/rails', branch: '4-0-stable'
+gem "mime-types", "< 3"

--- a/gemfiles/Gemfile-4-2-stable
+++ b/gemfiles/Gemfile-4-2-stable
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', github: 'rails/rails', branch: '4-1-stable'
+gem 'rails', github: 'rails/rails', branch: '4-2-stable'
 gem "mime-types", "< 3"


### PR DESCRIPTION
- Pin mime-types gem to < 3 to avoid problems installing it on Ruby 1.9
- This prevents installing mime-types-data (3.2016.0221) which fails on
  1.9.3 as it requires Ruby 2.

r? @rafaelfranca Same fix as coffee-rails and other gems.