### PR TITLE
Cache page with query string

### DIFF
--- a/lib/actionpack/page_caching/railtie.rb
+++ b/lib/actionpack/page_caching/railtie.rb
@@ -11,6 +11,7 @@ module ActionPack
 
       initializer "action_pack.page_caching.set_config", before: "action_controller.set_configs" do |app|
         app.config.action_controller.page_cache_directory ||= app.config.paths["public"].first
+        app.config.action_controller.page_cache_with_query_string ||= false
       end
     end
   end


### PR DESCRIPTION
Allow to generate one cache file per query string variant.

Added `config.action_controller.page_cache_with_query_string` to set the behavior globally (default to false), and `:with_query_string` option to `caches_page` method to set the behavior at the action level.


