### PR TITLE
Remove upper dependency for actionpack

### DIFF
--- a/actionpack-page_caching.gemspec
+++ b/actionpack-page_caching.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
-  gem.add_dependency "actionpack", ">= 4.0.0", "< 6"
+  gem.add_dependency "actionpack", ">= 4.0.0"
 
   gem.add_development_dependency "mocha"
 end


### PR DESCRIPTION
We are trying to test our application on rails 6.0.0.alpha but we can't install this because of the version lock
Probably this will be helpful that we can try and report any issues with edge rails