### PR TITLE
Remove reference to Gemnasium

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,4 +213,3 @@ Code Status
 -----------
 
 * [![Build Status](https://travis-ci.org/rails/actionpack-page_caching.svg?branch=master)](https://travis-ci.org/rails/actionpack-page_caching)
-* [![Dependency Status](https://gemnasium.com/rails/actionpack-page_caching.svg)](https://gemnasium.com/rails/actionpack-page_caching)


### PR DESCRIPTION
Gemnasium has been acquired and shutdown by Gitlab.

The reference here was showing an Fixme badge directing to Gitlab with
the message

> To avoid broken 404 images, all badges pointing to Gemnasium.com will be a placeholder, inviting you to migrate to GitLab