### PR TITLE
Fix for Rails 6 Mime lookups

### DIFF
--- a/lib/action_controller/caching/pages.rb
+++ b/lib/action_controller/caching/pages.rb
@@ -275,7 +275,13 @@ module ActionController
               request.path
             end
 
-          if (type = Mime::LOOKUP[self.content_type]) && (type_symbol = type.symbol).present?
+          type = if self.respond_to?(:media_type)
+                   Mime::LOOKUP[self.media_type]
+                 else
+                   Mime::LOOKUP[self.content_type]
+                 end
+
+          if type && (type_symbol = type.symbol).present?
             extension = ".#{type_symbol}"
           end
 


### PR DESCRIPTION
After Rails 5.2,  controller content_type contained the default charset
causing Mime::LOOKUP not to work.   This was addressed by adding a new
method called `media_type` which would allow Mime lookups to work.

In Rails 6.0 stable - `HTTP_ACCEPT` `text/xml` results in content_type of `application/xml; charset=utf-8`
In Rails <6 - `HTTP_ACCEPT` `text/xml` results in content_type of `application/xml`

So this code https://github.com/rails/actionpack-page_caching/pull/57/files#diff-f657665506f5a89385bc5a642eb317f1L278 would fail and the XML cache file would not be written.

This fix checks for the existence of the new method that returns the media type, otherwise reverting to the older behavior.  Has fixed tests for Rails 6 and edge.

This is the relevant commit in https://github.com/rails/rails/commit/ea5f509643d6d9c468a9b26f6c45bd4e40fd67cf#diff-0b53645cdb23933ef05759b2426f069a 
