### PR TITLE
Fix undefined method `eager_autoload` on edge Rails.

### DIFF
--- a/lib/action_controller/page_caching.rb
+++ b/lib/action_controller/page_caching.rb
@@ -2,6 +2,8 @@ require "action_controller/caching/pages"
 
 module ActionController
   module Caching
+    extend ActiveSupport::Autoload
+
     eager_autoload do
       autoload :Pages
     end


### PR DESCRIPTION
If this gem is used in an application using edge Rails, the app is failing to start with error: `undefined method 'eager_autoload' for ActionController::Caching:Module (NoMethodError)` [(proof)](https://travis-ci.com/github/khustochka/actionpack-page_caching/jobs/341245305)

The reason for that is that in Rails `ActionController::Caching` does not extend `ActiveSupport::Autoload` any more (https://github.com/rails/rails/commit/da21ac7bf9d8d2de4e9dbf4c137ad3e8ea50a495).

Thus this extension needs to be added back in the gem.