### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
 before_install:
   - gem install bundler
 
+arch: 
+   - amd64
+   - ppc64le
 rvm:
   - 2.4.6
   - 2.5.5


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/actionpack-page_caching/builds/199806556 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!